### PR TITLE
fix(grants): grant MCP app SP CAN_MANAGE_RUN on jobs at registration

### DIFF
--- a/modules/bionemo/notebooks/initialize.py
+++ b/modules/bionemo/notebooks/initialize.py
@@ -9,6 +9,7 @@ dbutils.widgets.text("bionemo_esm_finetune_job_id", "1234", "BioNeMo ESM Fine Tu
 dbutils.widgets.text("bionemo_esm_inference_job_id", "1234", "BioNeMo ESM Inference Job ID")
 dbutils.widgets.text("user_email", "a@b.com", "Email of the user running the deploy")
 dbutils.widgets.text("sql_warehouse_id", "8f210e00850a2c16", "SQL Warehouse Id")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("core_catalog")
 schema = dbutils.widgets.get("core_schema")
@@ -98,7 +99,11 @@ spark.sql(query)
 # COMMAND ----------
 
 #Grant app permission to run this job
+import os
 from genesis_workbench.workbench import set_app_permissions_for_job
+
+_app_names_raw = dbutils.widgets.get("databricks_app_names")
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in _app_names_raw.replace(":", ",").split(",") if n.strip()])  # UI + MCP
 
 set_app_permissions_for_job(job_id=bionemo_esm_finetune_job_id, user_email=user_email)
 set_app_permissions_for_job(job_id=bionemo_esm_inference_job_id, user_email=user_email)

--- a/modules/bionemo/resources/initial_setup.yml
+++ b/modules/bionemo/resources/initial_setup.yml
@@ -29,7 +29,9 @@ resources:
           default: ${resources.jobs.bionemo_esm_finetune.id}
         - name: bionemo_esm_inference_job_id
           default: ${resources.jobs.bionemo_esm_inference.id}
-        - name: sql_warehouse_id 
+        - name: sql_warehouse_id
           default: ${var.sql_warehouse_id}
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
 
       tags: ${var.common_resource_tags}

--- a/modules/core/app/requirements.txt
+++ b/modules/core/app/requirements.txt
@@ -8,4 +8,4 @@ mlflow[databricks]
 parasail==1.3.4
 biopython==1.84
 rdkit==2025.3.6
-backend/lib/genesis_workbench-0.1.34-py3-none-any.whl
+backend/lib/genesis_workbench-0.1.35-py3-none-any.whl

--- a/modules/core/library/genesis_workbench/pyproject.toml
+++ b/modules/core/library/genesis_workbench/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "genesis_workbench"
-version = "0.1.34"
+version = "0.1.35"
 description = "Genesis workbench for Databricks"
 authors = ["Srijit Nair <srijit.nair@databricks.com>", "Eli Swanson <eli.swanson@databricks.com>"]
 license = "DB License"

--- a/modules/core/library/genesis_workbench/src/genesis_workbench/workbench.py
+++ b/modules/core/library/genesis_workbench/src/genesis_workbench/workbench.py
@@ -292,8 +292,12 @@ def set_app_permissions_for_job(job_id:str, user_email:str):
             )
         )
 
-    # Set permissions on the job, replacing any previous ACL
-    w.jobs.set_permissions(
+    # ADDITIVE grant (PATCH semantics) — preserves any existing ACL rather than
+    # replacing it. Critical for multi-app installs: a module re-registration
+    # must NOT wipe a previously-granted sibling app (e.g. the MCP server SP,
+    # granted by grant_app_permissions_job). update_permissions only adds the
+    # owner + app grants listed here; set_permissions would clobber the rest.
+    w.jobs.update_permissions(
         job_id=job_id,
         access_control_list=acl
     )

--- a/modules/core/mcp_app/requirements.txt
+++ b/modules/core/mcp_app/requirements.txt
@@ -12,4 +12,4 @@ httpx-sse==0.4.3
 python-multipart==0.0.30
 anyio==4.13.0
 biopython==1.84
-backend/lib/genesis_workbench-0.1.34-py3-none-any.whl
+backend/lib/genesis_workbench-0.1.35-py3-none-any.whl

--- a/modules/genomics/gwas/gwas_v1/notebooks/initialize.py
+++ b/modules/genomics/gwas/gwas_v1/notebooks/initialize.py
@@ -8,6 +8,7 @@ dbutils.widgets.text("parabricks_alignment_job_id", "1234", "Parabricks Alignmen
 dbutils.widgets.text("gwas_analysis_job_id", "1234", "GWAS Analysis Job ID")
 dbutils.widgets.text("user_email", "a@b.com", "Email of the user running the deploy")
 dbutils.widgets.text("sql_warehouse_id", "8f210e00850a2c16", "SQL Warehouse Id")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("catalog")
 schema = dbutils.widgets.get("schema")
@@ -83,6 +84,10 @@ spark.sql(query)
 # COMMAND ----------
 
 from genesis_workbench.workbench import set_app_permissions_for_job
+
+import os
+_app_names_raw = dbutils.widgets.get("databricks_app_names")
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in _app_names_raw.replace(":", ",").split(",") if n.strip()])  # UI + MCP
 
 set_app_permissions_for_job(job_id=parabricks_alignment_job_id, user_email=user_email)
 set_app_permissions_for_job(job_id=gwas_analysis_job_id, user_email=user_email)

--- a/modules/genomics/gwas/gwas_v1/resources/initial_setup.yml
+++ b/modules/genomics/gwas/gwas_v1/resources/initial_setup.yml
@@ -42,6 +42,8 @@ resources:
           default: ${resources.jobs.gwas_analysis.id}
         - name: user_email
           default: ${var.current_user}
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
 
       job_clusters:
         - job_cluster_key: gwas_setup_cluster

--- a/modules/genomics/variant_annotation/variant_annotation_v1/notebooks/initialize.py
+++ b/modules/genomics/variant_annotation/variant_annotation_v1/notebooks/initialize.py
@@ -8,6 +8,7 @@ dbutils.widgets.text("variant_annotation_job_id", "1234", "Variant Annotation Jo
 dbutils.widgets.text("variant_annotation_dashboard_id", "1234", "Variant Annotation Dashboard ID")
 dbutils.widgets.text("user_email", "a@b.com", "Email of the user running the deploy")
 dbutils.widgets.text("sql_warehouse_id", "8f210e00850a2c16", "SQL Warehouse Id")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("catalog")
 schema = dbutils.widgets.get("schema")
@@ -130,6 +131,10 @@ spark.sql(query)
 # COMMAND ----------
 
 from genesis_workbench.workbench import set_app_permissions_for_job
+
+import os
+_app_names_raw = dbutils.widgets.get("databricks_app_names")
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in _app_names_raw.replace(":", ",").split(",") if n.strip()])  # UI + MCP
 
 set_app_permissions_for_job(job_id=variant_annotation_job_id, user_email=user_email)
 

--- a/modules/genomics/variant_annotation/variant_annotation_v1/resources/initial_setup.yml
+++ b/modules/genomics/variant_annotation/variant_annotation_v1/resources/initial_setup.yml
@@ -49,6 +49,8 @@ resources:
           default: ${resources.dashboards.variant_annotation_dashboard.id}
         - name: user_email
           default: ${var.current_user}
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
 
       job_clusters:
         - job_cluster_key: variant_annotation_setup_cluster

--- a/modules/genomics/vcf_ingestion/vcf_ingestion_v1/notebooks/initialize.py
+++ b/modules/genomics/vcf_ingestion/vcf_ingestion_v1/notebooks/initialize.py
@@ -7,6 +7,7 @@ dbutils.widgets.text("schema", "genesis_schema", "Schema")
 dbutils.widgets.text("vcf_ingestion_job_id", "1234", "VCF Ingestion Job ID")
 dbutils.widgets.text("user_email", "a@b.com", "Email of the user running the deploy")
 dbutils.widgets.text("sql_warehouse_id", "8f210e00850a2c16", "SQL Warehouse Id")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("catalog")
 schema = dbutils.widgets.get("schema")
@@ -70,6 +71,10 @@ spark.sql(query)
 # COMMAND ----------
 
 from genesis_workbench.workbench import set_app_permissions_for_job
+
+import os
+_app_names_raw = dbutils.widgets.get("databricks_app_names")
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in _app_names_raw.replace(":", ",").split(",") if n.strip()])  # UI + MCP
 
 set_app_permissions_for_job(job_id=vcf_ingestion_job_id, user_email=user_email)
 

--- a/modules/genomics/vcf_ingestion/vcf_ingestion_v1/resources/initial_setup.yml
+++ b/modules/genomics/vcf_ingestion/vcf_ingestion_v1/resources/initial_setup.yml
@@ -31,5 +31,7 @@ resources:
           default: ${resources.jobs.vcf_ingestion.id}
         - name: user_email
           default: ${var.current_user}
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
 
       tags: ${var.common_resource_tags}

--- a/modules/large_molecule/alphafold/alphafold_v2.3.2/notebooks/register_alphafold_job.py
+++ b/modules/large_molecule/alphafold/alphafold_v2.3.2/notebooks/register_alphafold_job.py
@@ -4,6 +4,7 @@ dbutils.widgets.text("schema", "dev_srijit_nair_dbx_genesis_workbench_core", "Sc
 dbutils.widgets.text("run_alphafold_job_id", "167486110869223", "AlphaFold Job ID")
 dbutils.widgets.text("user_email", "a@b.com", "Email of the user running the deploy")
 dbutils.widgets.text("sql_warehouse_id", "8f210e00850a2c16", "SQL Warehouse Id")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("catalog")
 schema = dbutils.widgets.get("schema")
@@ -66,6 +67,10 @@ from genesis_workbench.workbench import (
     set_app_permissions_for_job,
     set_app_permissions_for_volume,
 )
+
+import os
+_app_names_raw = dbutils.widgets.get("databricks_app_names")
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in _app_names_raw.replace(":", ",").split(",") if n.strip()])  # UI + MCP
 
 set_app_permissions_for_job(job_id=run_alphafold_job_id, user_email=user_email)
 

--- a/modules/large_molecule/alphafold/alphafold_v2.3.2/resources/register_and_download.yml
+++ b/modules/large_molecule/alphafold/alphafold_v2.3.2/resources/register_and_download.yml
@@ -117,6 +117,8 @@ resources:
           default: ${var.sql_warehouse_id}
         - name: run_alphafold_job_id
           default: ${resources.jobs.alphafold.id}
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
 
               
       job_clusters:

--- a/modules/large_molecule/enzyme_optimization/enzyme_optimization_v1/notebooks/register_enzyme_optimization_job.py
+++ b/modules/large_molecule/enzyme_optimization/enzyme_optimization_v1/notebooks/register_enzyme_optimization_job.py
@@ -18,6 +18,7 @@ dbutils.widgets.text("run_enzyme_optimization_inprocess_ame_job_id", "", "Accura
 dbutils.widgets.text("user_email", "a@b.com", "User email")
 dbutils.widgets.text("sql_warehouse_id", "8f210e00850a2c16", "SQL Warehouse Id")
 dbutils.widgets.text("databricks_app_name", "genesis-workbench", "Databricks App Name")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("catalog")
 schema = dbutils.widgets.get("schema")
@@ -50,9 +51,11 @@ run_enzyme_optimization_inprocess_ame_job_id = dbutils.widgets.get("run_enzyme_o
 user_email = dbutils.widgets.get("user_email")
 sql_warehouse_id = dbutils.widgets.get("sql_warehouse_id")
 databricks_app_name = dbutils.widgets.get("databricks_app_name")
+databricks_app_names = dbutils.widgets.get("databricks_app_names") or databricks_app_name
 
 import os
-os.environ["DATABRICKS_APP_NAME"] = databricks_app_name
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in databricks_app_names.replace(":", ",").split(",") if n.strip()])  # UI + MCP
+os.environ["DATABRICKS_APP_NAME"] = databricks_app_name  # legacy single-app fallback
 
 # COMMAND ----------
 

--- a/modules/large_molecule/enzyme_optimization/enzyme_optimization_v1/resources/register_enzyme_optimization_job.yml
+++ b/modules/large_molecule/enzyme_optimization/enzyme_optimization_v1/resources/register_enzyme_optimization_job.yml
@@ -45,5 +45,7 @@ resources:
           default: ${var.sql_warehouse_id}
         - name: databricks_app_name
           default: ${var.app_name}
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
 
       tags: ${var.common_resource_tags}

--- a/modules/single_cell/rapidssinglecell/rapidssinglecell_v0.0.1/notebooks/register_rapidssinglecell_job.py
+++ b/modules/single_cell/rapidssinglecell/rapidssinglecell_v0.0.1/notebooks/register_rapidssinglecell_job.py
@@ -4,6 +4,7 @@ dbutils.widgets.text("core_schema", "genesis_schema", "Schema")
 dbutils.widgets.text("run_rapidssinglecell_job_id", "", "Rapids-SingleCell Job ID")
 dbutils.widgets.text("user_email", "a@b.com", "Email of the user running the deploy")
 dbutils.widgets.text("sql_warehouse_id", "", "SQL Warehouse Id")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("core_catalog")
 schema = dbutils.widgets.get("core_schema")
@@ -62,7 +63,11 @@ WHEN NOT MATCHED THEN INSERT (key, value, module) VALUES (source.key, source.val
 # COMMAND ----------
 
 #Grant app permission to run this job
+import os
 from genesis_workbench.workbench import set_app_permissions_for_job
+
+_app_names_raw = dbutils.widgets.get("databricks_app_names")
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in _app_names_raw.replace(":", ",").split(",") if n.strip()])  # UI + MCP
 
 set_app_permissions_for_job(job_id=run_rapidssinglecell_job_id, user_email=user_email)
 

--- a/modules/single_cell/rapidssinglecell/rapidssinglecell_v0.0.1/resources/register_rapidssinglecell_job.yml
+++ b/modules/single_cell/rapidssinglecell/rapidssinglecell_v0.0.1/resources/register_rapidssinglecell_job.yml
@@ -30,7 +30,9 @@ resources:
           default: ${var.current_user}
         - name: sql_warehouse_id
           default: ${var.sql_warehouse_id}
-      
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
+
       tags: ${var.common_resource_tags}
 
 

--- a/modules/single_cell/scanpy/scanpy_v0.0.1/notebooks/register_scanpy_job.py
+++ b/modules/single_cell/scanpy/scanpy_v0.0.1/notebooks/register_scanpy_job.py
@@ -4,6 +4,7 @@ dbutils.widgets.text("core_schema", "genesis_schema", "Schema")
 dbutils.widgets.text("run_scanpy_job_id", "", "Scanpy Job ID")
 dbutils.widgets.text("user_email", "a@b.com", "Email of the user running the deploy")
 dbutils.widgets.text("sql_warehouse_id", "", "SQL Warehouse Id")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("core_catalog")
 schema = dbutils.widgets.get("core_schema")
@@ -62,10 +63,14 @@ WHEN NOT MATCHED THEN INSERT (key, value, module) VALUES (source.key, source.val
 # COMMAND ----------
 
 #Grant app permission to run this job
+import os
 from genesis_workbench.workbench import (
     set_app_permissions_for_job,
     set_app_permissions_for_volume,
 )
+
+_app_names_raw = dbutils.widgets.get("databricks_app_names")
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in _app_names_raw.replace(":", ",").split(",") if n.strip()])  # UI + MCP
 
 set_app_permissions_for_job(job_id=run_scanpy_job_id, user_email=user_email)
 

--- a/modules/single_cell/scanpy/scanpy_v0.0.1/resources/register_scanpy_job.yml
+++ b/modules/single_cell/scanpy/scanpy_v0.0.1/resources/register_scanpy_job.yml
@@ -30,6 +30,8 @@ resources:
           default: ${var.current_user}
         - name: sql_warehouse_id
           default: ${var.sql_warehouse_id}
-      
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
+
       tags: ${var.common_resource_tags}
 

--- a/modules/small_molecule/genmol/genmol_v1/notebooks/register_molecule_optimization_job.py
+++ b/modules/small_molecule/genmol/genmol_v1/notebooks/register_molecule_optimization_job.py
@@ -16,6 +16,7 @@ dbutils.widgets.text("run_molecule_optimization_job_id", "", "Orchestrator Job I
 dbutils.widgets.text("user_email", "a@b.com", "User Id/Email")
 dbutils.widgets.text("sql_warehouse_id", "w123", "SQL Warehouse Id")
 dbutils.widgets.text("databricks_app_name", "genesis-workbench", "Databricks App name")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("catalog")
 schema = dbutils.widgets.get("schema")
@@ -46,9 +47,11 @@ run_molecule_optimization_job_id = dbutils.widgets.get("run_molecule_optimizatio
 user_email = dbutils.widgets.get("user_email")
 sql_warehouse_id = dbutils.widgets.get("sql_warehouse_id")
 databricks_app_name = dbutils.widgets.get("databricks_app_name")
+databricks_app_names = dbutils.widgets.get("databricks_app_names") or databricks_app_name
 
 import os
-os.environ["DATABRICKS_APP_NAME"] = databricks_app_name
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in databricks_app_names.replace(":", ",").split(",") if n.strip()])  # UI + MCP
+os.environ["DATABRICKS_APP_NAME"] = databricks_app_name  # legacy single-app fallback
 
 # COMMAND ----------
 

--- a/modules/small_molecule/genmol/genmol_v1/resources/register_molecule_optimization_job.yml
+++ b/modules/small_molecule/genmol/genmol_v1/resources/register_molecule_optimization_job.yml
@@ -43,5 +43,7 @@ resources:
           default: ${var.sql_warehouse_id}
         - name: databricks_app_name
           default: ${var.app_name}
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
 
       tags: ${var.common_resource_tags}

--- a/modules/small_molecule/kermt/kermt_v1/notebooks/register_kermt_jobs.py
+++ b/modules/small_molecule/kermt/kermt_v1/notebooks/register_kermt_jobs.py
@@ -16,6 +16,7 @@ dbutils.widgets.text("user_email", "srijit.nair@databricks.com", "User Id/Email"
 dbutils.widgets.text("kermt_finetune_job_id", "", "KERMT finetune orchestrator job id")
 dbutils.widgets.text("kermt_deploy_job_id", "", "KERMT deploy orchestrator job id")
 dbutils.widgets.text("databricks_app_name", "genesis-workbench", "Databricks App Name")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("catalog")
 schema = dbutils.widgets.get("schema")
@@ -43,8 +44,11 @@ sql_warehouse_id, user_email = g("sql_warehouse_id"), g("user_email")
 kermt_finetune_job_id = g("kermt_finetune_job_id")
 kermt_deploy_job_id = g("kermt_deploy_job_id")
 databricks_app_name = g("databricks_app_name")
+databricks_app_names = dbutils.widgets.get("databricks_app_names") or databricks_app_name
 
-os.environ["DATABRICKS_APP_NAME"] = databricks_app_name  # set BEFORE importing helpers
+# set BEFORE importing helpers
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in databricks_app_names.replace(":", ",").split(",") if n.strip()])  # UI + MCP
+os.environ["DATABRICKS_APP_NAME"] = databricks_app_name  # legacy single-app fallback
 
 from genesis_workbench.workbench import initialize, set_app_permissions_for_job
 from genesis_workbench.models import register_batch_model, ModelCategory

--- a/modules/small_molecule/kermt/kermt_v1/resources/register_kermt.yml
+++ b/modules/small_molecule/kermt/kermt_v1/resources/register_kermt.yml
@@ -47,6 +47,8 @@ resources:
           default: ${resources.jobs.kermt_deploy.id}
         - name: databricks_app_name
           default: genesis-workbench
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
 
       job_clusters:
         - job_cluster_key: stage_cluster

--- a/modules/small_molecule/kermt/kermt_v2/notebooks/register_kermt_jobs.py
+++ b/modules/small_molecule/kermt/kermt_v2/notebooks/register_kermt_jobs.py
@@ -16,6 +16,7 @@ dbutils.widgets.text("user_email", "srijit.nair@databricks.com", "User Id/Email"
 dbutils.widgets.text("kermt_finetune_job_id", "", "KERMT finetune orchestrator job id")
 dbutils.widgets.text("kermt_deploy_job_id", "", "KERMT deploy orchestrator job id")
 dbutils.widgets.text("databricks_app_name", "genesis-workbench", "Databricks App Name")
+dbutils.widgets.text("databricks_app_names", "genesis-workbench:mcp-genesis-workbench", "Databricks App Names (colon/comma-separated, UI + MCP)")
 
 catalog = dbutils.widgets.get("catalog")
 schema = dbutils.widgets.get("schema")
@@ -43,8 +44,11 @@ sql_warehouse_id, user_email = g("sql_warehouse_id"), g("user_email")
 kermt_finetune_job_id = g("kermt_finetune_job_id")
 kermt_deploy_job_id = g("kermt_deploy_job_id")
 databricks_app_name = g("databricks_app_name")
+databricks_app_names = dbutils.widgets.get("databricks_app_names") or databricks_app_name
 
-os.environ["DATABRICKS_APP_NAME"] = databricks_app_name  # set BEFORE importing helpers
+# set BEFORE importing helpers
+os.environ["DATABRICKS_APP_NAMES"] = ",".join([n.strip() for n in databricks_app_names.replace(":", ",").split(",") if n.strip()])  # UI + MCP
+os.environ["DATABRICKS_APP_NAME"] = databricks_app_name  # legacy single-app fallback
 
 from genesis_workbench.workbench import initialize, set_app_permissions_for_job
 from genesis_workbench.models import register_batch_model, ModelCategory

--- a/modules/small_molecule/kermt/kermt_v2/resources/register_kermt.yml
+++ b/modules/small_molecule/kermt/kermt_v2/resources/register_kermt.yml
@@ -47,6 +47,8 @@ resources:
           default: ${resources.jobs.kermt_deploy.id}
         - name: databricks_app_name
           default: genesis-workbench
+        - name: databricks_app_names
+          default: genesis-workbench:mcp-genesis-workbench
 
       job_clusters:
         - job_cluster_key: stage_cluster


### PR DESCRIPTION
Jobs were not getting the MCP server app SP granted the way endpoints are. Endpoints flow through deploy_model -> set_app_permissions_for_endpoint and already read DATABRICKS_APP_NAMES (= var.app_names, both UI + MCP). Jobs go through each module's register notebook -> set_app_permissions_for_job, which only knew the single UI app (or no app at all), so the MCP SP relied entirely on the bulk grant_app_permissions_job.

Two changes:

Part 1 (per-module): every job-registration notebook now sets DATABRICKS_APP_NAMES (UI + MCP) before set_app_permissions_for_job, fed by a new databricks_app_names parameter on each register job (default genesis-workbench:mcp-genesis-workbench). Covers kermt v1/v2, genmol, enzyme, alphafold, rapidssinglecell, scanpy, genomics (gwas/vcf/variant_annotation), bionemo.

Part 2 (library): set_app_permissions_for_job switches from w.jobs.set_permissions (REPLACE) to additive w.jobs.update_permissions, so a module re-registration can no longer clobber a previously-granted sibling app. Wheel bumped 0.1.34 -> 0.1.35 (+ app/mcp_app requirements refs).

Net: deploy any module on any workspace and both the UI and MCP SPs get CAN_MANAGE_RUN on its jobs automatically, durably across re-registration.

Co-authored-by: Isaac